### PR TITLE
Feature 37 vert interp

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -48,8 +48,9 @@ Describe the steps to reproduce the behavior:
 - [ ] Select **requestor(s)**
 
 ### Projects and Milestone ###
-- [ ] Review **projects** and select relevant **Repository** and **Organization** ones or add "alert:NEED PROJECT ASSIGNMENT" label
-- [ ] Select **milestone** to relevant bugfix version
+- [ ] Select **Organization** level **Project** for support of the current coordinated release
+- [ ] Select **Repository** level **Project** for development toward the next official release or add **alert: NEED PROJECT ASSIGNMENT** label
+- [ ] Select **Milestone** as the next bugfix version
 
 ## Define Related Issue(s) ##
 Consider the impact to the other METplus components.
@@ -68,10 +69,15 @@ Branch name: `bugfix_<Issue Number>_main_<Version>_<Description>`
 - [ ] Submit a pull request to merge into **main_\<Version>**.
 Pull request: `bugfix <Issue Number> main_<Version> <Description>`
 - [ ] Define the pull request metadata, as permissions allow.
-Select: **Reviewer(s)**, **Project(s)**, **Milestone**, and **Linked issues**
+Select: **Reviewer(s)** and **Linked issues**
+Select: **Organization** level software support **Project** for the current coordinated release
+Select: **Milestone** as the next bugfix version
 - [ ] Iterate until the reviewer(s) accept and merge your changes.
 - [ ] Delete your fork or branch.
 - [ ] Complete the steps above to fix the bug on the **develop** branch.
 Branch name:  `bugfix_<Issue Number>_develop_<Description>`
 Pull request: `bugfix <Issue Number> develop <Description>`
+Select: **Reviewer(s)** and **Linked issues**
+Select: **Repository** level development cycle **Project** for the next official release
+Select: **Milestone** as the next official version
 - [ ] Close this issue.

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -38,8 +38,8 @@ Consider breaking the enhancement down into sub-issues.
 - [ ] Select **requestor(s)**
 
 ### Projects and Milestone ###
-- [ ] Review **projects** and select relevant **Repository** and **Organization** ones or add "alert:NEED PROJECT ASSIGNMENT" label
-- [ ] Select **milestone** to next major version milestone or "Future Versions"
+- [ ] Select **Repository** and/or **Organization** level **Project(s)** or add **alert: NEED PROJECT ASSIGNMENT** label
+- [ ] Select **Milestone** as the next official version or **Future Versions**
 
 ## Define Related Issue(s) ##
 Consider the impact to the other METplus components.
@@ -58,7 +58,9 @@ Branch name: `feature_<Issue Number>_<Description>`
 - [ ] Submit a pull request to merge into **develop**.
 Pull request: `feature <Issue Number> <Description>`
 - [ ] Define the pull request metadata, as permissions allow.
-Select: **Reviewer(s)**, **Project(s)**, **Milestone**, and **Linked issues**
+Select: **Reviewer(s)** and **Linked issues**
+Select: **Repository** level development cycle **Project** for the next official release
+Select: **Milestone** as the next official version
 - [ ] Iterate until the reviewer(s) accept and merge your changes.
 - [ ] Delete your fork or branch.
 - [ ] Close this issue.

--- a/.github/ISSUE_TEMPLATE/new_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/new_feature_request.md
@@ -42,8 +42,8 @@ Consider breaking the new feature down into sub-issues.
 - [ ] Select **requestor(s)**
 
 ### Projects and Milestone ###
-- [ ] Review **projects** and select relevant **Repository** and **Organization** ones or add "alert:NEED PROJECT ASSIGNMENT" label
-- [ ] Select **milestone** to next major version milestone or "Future Versions"
+- [ ] Select **Repository** and/or **Organization** level **Project(s)** or add **alert: NEED PROJECT ASSIGNMENT** label
+- [ ] Select **Milestone** as the next official version or **Future Versions**
 
 ## Define Related Issue(s) ##
 Consider the impact to the other METplus components.
@@ -62,7 +62,9 @@ Branch name: `feature_<Issue Number>_<Description>`
 - [ ] Submit a pull request to merge into **develop**.
 Pull request: `feature <Issue Number> <Description>`
 - [ ] Define the pull request metadata, as permissions allow.
-Select: **Reviewer(s)**, **Project(s)**, **Milestone**, and **Linked issues**
+Select: **Reviewer(s)** and **Linked issues**
+Select: **Repository** level development cycle **Project** for the next official release
+Select: **Milestone** as the next official version
 - [ ] Iterate until the reviewer(s) accept and merge your changes.
 - [ ] Delete your fork or branch.
 - [ ] Close this issue.

--- a/.github/ISSUE_TEMPLATE/sub-issue.md
+++ b/.github/ISSUE_TEMPLATE/sub-issue.md
@@ -28,5 +28,5 @@ This is a sub-issue of #*List the parent issue number here*.
 - [ ] Select **requestor(s)**
 
 ### Projects and Milestone ###
-- [ ] Review **projects** and select relevant **Repository** and **Organization** ones or add "alert:NEED PROJECT ASSIGNMENT" label
-- [ ] Select **milestone** to next major version milestone or "Future Versions"
+- [ ] Select **Repository** and/or **Organization** level **Project(s)** or add **alert: NEED PROJECT ASSIGNMENT** label
+- [ ] Select **Milestone** as the next official version or **Future Versions**

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -38,8 +38,8 @@ Consider breaking the task down into sub-issues.
 - [ ] Select **requestor(s)**
 
 ### Projects and Milestone ###
-- [ ] Review **projects** and select relevant **Repository** and **Organization** ones or add "alert:NEED PROJECT ASSIGNMENT" label
-- [ ] Select **milestone** to next major version milestone or "Future Versions"
+- [ ] Select **Repository** and/or **Organization** level **Project(s)** or add **alert: NEED PROJECT ASSIGNMENT** label
+- [ ] Select **Milestone** as the next official version or **Future Versions**
 
 ## Define Related Issue(s) ##
 Consider the impact to the other METplus components.
@@ -58,7 +58,9 @@ Branch name: `feature_<Issue Number>_<Description>`
 - [ ] Submit a pull request to merge into **develop**.
 Pull request: `feature <Issue Number> <Description>`
 - [ ] Define the pull request metadata, as permissions allow.
-Select: **Reviewer(s)**, **Project(s)**, **Milestone**, and **Linked issues**
+Select: **Reviewer(s)** and **Linked issues**
+Select: **Repository** level development cycle **Project** for the next official release
+Select: **Milestone** as the next official version
 - [ ] Iterate until the reviewer(s) accept and merge your changes.
 - [ ] Delete your fork or branch.
 - [ ] Close this issue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,9 @@ See the [METplus Workflow](https://dtcenter.github.io/METplus/Contributors_Guide
 - [ ] Complete the PR definition above.
 - [ ] Ensure the PR title matches the feature or bugfix branch name.
 - [ ] Define the PR metadata, as permissions allow.
-Select: **Reviewer(s)**, **Project(s)**, and **Milestone**
-- [ ] After submitting the PR, select **Linked Issues** with the original issue number.
+Select: **Reviewer(s)**
+Select: **Organization** level software support **Project** or **Repository** level development cycle **Project**
+Select: **Milestone** as the version that will include these changes
+- [ ] After submitting the PR, select **Linked issues** with the original issue number.
 - [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
 - [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ repository.
 
 Support for the METplus components is provided through the
 [METplus Discussions](https://github.com/dtcenter/METplus/discussions) forum.
-Users are welcome and encouraged to answer or address each other’s questions there!  For more
+Users are welcome and encouraged to answer or address each other's questions there!  For more
 information, please read
-"[Welcome to the METplus Components Discussions](https://giithub.com/dtcenter/METplus/discussions/939)".
+"[Welcome to the METplus Components Discussions](https://github.com/dtcenter/METplus/discussions/939)".

--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 A repository containing packages for plotting in METplus as stand-alone, or part of METplus use case,
 METplus wrappers, METexpress, or METviewer.  There may be dependencies on external packages, ie packages in the METcalcpy
 repository.
+
+Support for the METplus components is provided through the
+[METplus Discussions](https://github.com/dtcenter/METplus/discussions) forum.
+Users are welcome and encouraged to answer or address each other’s questions there!  For more
+information, please read
+"[Welcome to the METplus Components Discussions](https://giithub.com/dtcenter/METplus/discussions/939)".

--- a/metplotpy/contributed/tc_rmw/plot_cross_section.py
+++ b/metplotpy/contributed/tc_rmw/plot_cross_section.py
@@ -4,19 +4,38 @@ import argparse
 import logging
 import numpy as np
 import matplotlib
+import yaml
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap
 from tc_utils import read_tcrmw, format_valid_time, \
     radial_tangential_winds, height_from_pressure
 
-def plot_cross_section(plotdir,
+def plot_cross_section(config, plotdir,
     valid_time, range_grid, pressure_grid,
-    wind_data, scalar_data, by_pressure_lvl,
+    wind_data, scalar_data,
     field='TMP', track_index=0):
     """
        Generate the cross-section plot of the tangential and radial wind
     """
+
+    # Retrieve vertical level information: coordinate input type, dimension name, and vertical levels
+    vert_coord_input_type = config['vertical_coord_type_in']
+    vert_dimension_name = config['vertical_dim_name']
+    vert_levels = config['vertical_levels']
+    y_tick_step = config['vertical_level_stepsize'][0]
+    if vert_dimension_name == "pressure":
+        by_pressure_lvl = True
+        levels = np.array(vert_levels)
+        # determine the starting and ending PRESSURE levels
+        start_level = np.amax(levels)
+        end_level = np.amin(levels)
+    else:
+        by_pressure_lvl = False
+        levels = np.array(vert_levels)
+        # determine the starting and ending HEIGHT levels
+        start_level = np.amax(levels)
+        end_level = np.amin(levels)
 
     # azimuthal mean
     wind_radial = np.mean(wind_data['radial'], axis=1)
@@ -26,6 +45,8 @@ def plot_cross_section(plotdir,
     logging.debug(wind_tangential.shape)
     logging.debug(scalar_field.shape)
 
+    # Generate two plots, one for tangential cross-section and the other
+    # for radial cross-section winds
     wind_types = ['tangential', 'radial']
     for wt in wind_types:
         fig, ax = plt.subplots(figsize=(8., 4.5))
@@ -57,23 +78,28 @@ def plot_cross_section(plotdir,
             ax.set_yscale('symlog')
 
             # provide support for wind data in pressure or height
+            min_y_tick = config['vertical_levels'][0]
+            num_vert_levels = len(config['vertical_levels']) -1
+            max_y_tick = config['vertical_levels'][num_vert_levels]
+
             if by_pressure_lvl:
                 ax.set_ylabel('Pressure (mb)')
-                ax.set_ylim(1000, 250)
-                ax.set_yticks(np.arange(1000, 250, -100))
-                ax.set_yticklabels(np.arange(1000, 250, -100))
+                ax.set_ylim(start_level, end_level)
+                ax.set_yticks(np.arange(start_level, end_level, y_tick_step))
+                ax.set_yticklabels(np.arange(start_level, end_level, y_tick_step))
             else:
                 ax.set_ylabel('Height (m)')
-                ax.set_ylim(110, 10359)
-                ax.set_yticks(np.arange(110, 10359, 1000))
-                ax.set_yticklabels(np.arange(110, 10359, 1000))
+                ax.set_ylim(start_level, end_level)
+                ax.set_yticks(np.arange(start_level, end_level, y_tick_step))
+                ax.set_yticklabels(np.arange(start_level, end_level, y_tick_step))
 
             tang_outfile = os.path.join(plotdir,
                                         'tangential_cross_section_' + str(valid_time[track_index]))
-            
+
             fig.savefig(tang_outfile + '.png', dpi=300)
             fig.savefig(tang_outfile + '.pdf')
         else:
+            # Radial wind
             wind_contour = ax.contour(range_grid, pressure_grid,
                                       wind_radial[:, :, track_index].transpose(),
                                       levels=np.arange(5, 40, 5), colors='darkgreen', linewidths=1)
@@ -98,14 +124,20 @@ def plot_cross_section(plotdir,
             # provide support for wind data in pressure or height
             if by_pressure_lvl:
                 ax.set_ylabel('Pressure (mb)')
-                ax.set_ylim(1000, 250)
-                ax.set_yticks(np.arange(1000, 250, -100))
-                ax.set_yticklabels(np.arange(1000, 250, -100))
+                # ax.set_ylim(1000, 250)
+                # ax.set_yticks(np.arange(1000, 250, -100))
+                # ax.set_yticklabels(np.arange(1000, 250, -100))
+                ax.set_ylim(start_level, end_level)
+                ax.set_yticks(np.arange(start_level, end_level, y_tick_step))
+                ax.set_yticklabels(np.arange(start_level, end_level, y_tick_step))
             else:
                 ax.set_ylabel('Height (m)')
-                ax.set_ylim(110, 10359)
-                ax.set_yticks(np.arange(110, 10359, 1000))
-                ax.set_yticklabels(np.arange(110, 10359, 1000))
+                # ax.set_ylim(110, 10359)
+                # ax.set_yticks(np.arange(110, 10359, 1000))
+                # ax.set_yticklabels(np.arange(110, 10359, 1000))
+                ax.set_ylim(start_level, end_level)
+                ax.set_yticks(np.arange(start_level, end_level, y_tick_step))
+                ax.set_yticklabels(np.arange(start_level, end_level, y_tick_step))
 
             rad_outfile = os.path.join(plotdir,
                                        'radial_cross_section_' + str(valid_time[track_index]))
@@ -128,15 +160,22 @@ if __name__ == '__main__':
     parser.add_argument(
         '--filename', type=str, dest='filename',
         required=True)
-    parser.add_argument(
-        '--by_pressure_lvl', type=str, dest='by_pressure_lvl',
-        required=True)
-
+    parser.add_argument('--config', type=str,
+                        required=True,
+                        help='configuration file')
 
     args = parser.parse_args()
 
+    """
+       Read YAML configuration file
+       """
+    config = yaml.load(
+        open(args.config), Loader=yaml.FullLoader)
+    logging.info(config)
+
     logging.basicConfig(stream=sys.stdout,
-        level=logging.INFO)
+        level=logging.DEBUG)
+
 
     valid_time, lat_grid, lon_grid, \
         range_grid, azimuth_grid, pressure_grid, \
@@ -147,10 +186,11 @@ if __name__ == '__main__':
     logging.debug(wind_data.keys())
     logging.debug(scalar_data.keys())
 
-    radial_tangential_winds(
+    radial_tangential_wind_data = radial_tangential_winds(
         valid_time, range_grid, azimuth_grid, pressure_grid, wind_data)
 
-    logging.debug(wind_data.keys())
+    # logging.debug(wind_data.keys())
+    logging.debug(radial_tangential_wind_data.keys())
 
-    plot_cross_section(args.plotdir, valid_time, range_grid, pressure_grid,
-        wind_data, scalar_data, args.by_pressure_lvl)
+    plot_cross_section(config, args.plotdir, valid_time, range_grid, pressure_grid,
+                       radial_tangential_wind_data, scalar_data)

--- a/metplotpy/contributed/tc_rmw/plot_cross_section.py
+++ b/metplotpy/contributed/tc_rmw/plot_cross_section.py
@@ -18,92 +18,102 @@ def plot_cross_section(plotdir,
        Generate the cross-section plot of the tangential and radial wind
     """
 
-    if by_pressure_lvl:
-        print("by pressure level (mb)")
-    else:
-        print("by vertical interp (meters)")
+    wind_types = ['tangential', 'radial']
+    for wt in wind_types:
+        fig, ax = plt.subplots(figsize=(8., 4.5))
+        ax.plot([1, 1], [1000, 50], color='lightgrey')
 
-    # fig = plt.figure(1, figsize=(8., 4.5))
-    # ax = plt.axes()
-    fig,ax = plt.subplots(figsize=(8., 4.5))
-    fig2, ax2 = plt.subplots(figsize=(8., 4.5))
-    ax.plot([1, 1], [1000, 50], color='lightgrey')
-    ax2.plot([1, 1], [1000, 50], color='lightgrey')
+        plt.title(
+            format_valid_time(int(valid_time[track_index])))
 
-    plt.title(
-        format_valid_time(int(valid_time[track_index])))
+        # azimuthal mean
+        wind_radial = np.mean(wind_data['radial'], axis=1)
+        wind_tangential = np.mean(wind_data['tangential'], axis=1)
+        scalar_field = np.mean(scalar_data[field], axis=1)
+        logging.debug(wind_radial.shape)
+        logging.debug(wind_tangential.shape)
+        logging.debug(scalar_field.shape)
 
-    # azimuthal mean
-    wind_radial = np.mean(wind_data['radial'], axis=1)
-    wind_tangential = np.mean(wind_data['tangential'], axis=1)
-    scalar_field = np.mean(scalar_data[field], axis=1)
-    logging.debug(wind_radial.shape)
-    logging.debug(wind_tangential.shape)
-    logging.debug(scalar_field.shape)
+        if wt == 'tangential':
+            wind_contour = ax.contour(range_grid, pressure_grid,
+                                      wind_tangential[:, :, track_index].transpose(),
+                                      levels=np.arange(5, 40, 5), colors='darkgreen', linewidths=1)
+            ax.clabel(wind_contour, colors='darkgreen', fmt='%1.0f')
 
-    wind_contour = ax.contour(range_grid, pressure_grid,
-        wind_tangential[:,:,track_index].transpose(),
-        levels=np.arange(5, 40, 5), colors='darkgreen', linewidths=1)
-    ax.clabel(wind_contour, colors='darkgreen', fmt='%1.0f')
+            scalar_contour = ax.contour(range_grid, pressure_grid,
+                                        scalar_field[:, :, track_index].transpose(),
+                                        levels=np.arange(250, 300, 10), colors='darkblue',
+                                        linewidths=1)
 
-    scalar_contour = ax.contour(range_grid, pressure_grid,
-        scalar_field[:,:,track_index].transpose(),
-        levels=np.arange(250, 300, 10), colors='darkblue',
-        linewidths=1)
-    scalar_contour = ax2.contour(range_grid, pressure_grid,
-                                scalar_field[:, :, track_index].transpose(),
-                                levels=np.arange(250, 300, 10), colors='darkblue',
-                                linewidths=1)
-    ax.clabel(scalar_contour, colors='darkblue', fmt='%1.0f')
-    ax2.clabel(scalar_contour, colors='darkblue', fmt='%1.0f')
+            ax.clabel(scalar_contour, colors='darkblue', fmt='%1.0f')
 
+            ax.annotate('Tangential Wind (m s-1)', xy=(14, 350), color='darkgreen')
+            ax.annotate('Temperature (K)', xy=(14, 370), color='darkblue')
 
-    ax.annotate('Tangential Wind (m s-1)', xy=(14, 350), color='darkgreen')
-    ax2.annotate('Radial Wind (m s-1)', xy=(14, 350), color='darkgreen')
-    ax.annotate('Temperature (K)', xy=(14, 370), color='darkblue')
-    ax2.annotate('Temperature (K)', xy=(14, 370), color='darkblue')
+            ax.set_xlabel(
+                'Range (RMW = %4.1f km)' % track_data['RMW'][track_index])
+            ax.set_xticks(np.arange(1, 20))
 
-    ax.set_xlabel(
-        'Range (RMW = %4.1f km)' % track_data['RMW'][track_index])
-    ax2.set_xlabel(
-        'Range (RMW = %4.1f km)' % track_data['RMW'][track_index])
-    ax.set_xticks(np.arange(1, 20))
-    ax2.set_xticks(np.arange(1, 20))
+            ax.set_yscale('symlog')
 
-    ax.set_yscale('symlog')
-    ax2.set_yscale('symlog')
+            if by_pressure_lvl:
+                ax.set_ylabel('Pressure (mb)')
+                ax.set_ylim(1000, 250)
+                ax.set_yticks(np.arange(1000, 250, -100))
+                ax.set_yticklabels(np.arange(1000, 250, -100))
+            else:
+                ax.set_ylabel('Height (m)')
+                ax.set_ylim(110, 10359)
+                ax.set_yticks(np.arange(110, 10359, 1000))
+                ax.set_yticklabels(np.arange(110, 10359, 1000))
 
-    if by_pressure_lvl:
-        ax.set_ylabel('Pressure (mb)')
-        ax2.set_ylabel('Pressure (mb)')
-        ax.set_ylim(1000, 250)
-        ax2.set_ylim(1000, 250)
-        ax.set_yticks(np.arange(1000, 250, -100))
-        ax2.set_yticks(np.arange(1000, 250, -100))
-        ax.set_yticklabels(np.arange(1000, 250, -100))
-        ax2.set_yticklabels(np.arange(1000, 250, -100))
-    else:
-        ax.set_ylabel('Height (m)')
-        ax2.set_ylabel('Height (m)')
-        ax.set_ylim(110, 10359)
-        ax2.set_ylim(110,10359)
-        ax.set_yticks(np.arange(110, 10359, 1000))
-        ax2.set_yticks(np.arange(110, 10359, 1000))
-        ax.set_yticklabels(np.arange(110, 10359, 1000))
-        ax2.set_yticklabels(np.arange(110, 10359, 1000))
+            tang_outfile = os.path.join(plotdir,
+                                        'tangential_cross_section_' + str(valid_time[track_index]))
+            # plt.savefig(os.path.join(plotdir, 'tc_cross_section.png'), dpi=300)
+            # plt.savefig(os.path.join(plotdir, 'tc_cross_section.pdf'))
 
+            fig.savefig(tang_outfile + '.png', dpi=300)
+            fig.savefig(tang_outfile + '.pdf')
+        else:
+            wind_contour = ax.contour(range_grid, pressure_grid,
+                                      wind_radial[:, :, track_index].transpose(),
+                                      levels=np.arange(5, 40, 5), colors='darkgreen', linewidths=1)
+            ax.clabel(wind_contour, colors='darkgreen', fmt='%1.0f')
 
-    tang_outfile = os.path.join(plotdir,
-        'tangential_cross_section_' + str(valid_time[track_index]))
-    rad_outfile = os.path.join(plotdir,
-                                'radial_cross_section_' + str(valid_time[track_index]))
-    # plt.savefig(os.path.join(plotdir, 'tc_cross_section.png'), dpi=300)
-    # plt.savefig(os.path.join(plotdir, 'tc_cross_section.pdf'))
+            scalar_contour = ax.contour(range_grid, pressure_grid,
+                                        scalar_field[:, :, track_index].transpose(),
+                                        levels=np.arange(250, 300, 10), colors='darkblue',
+                                        linewidths=1)
 
-    fig.savefig(tang_outfile + '.png', dpi=300)
-    # fig.savefig(tang_outfile + '.pdf')
-    fig2.savefig(rad_outfile + '.png', dpi=300)
-    # fig2.savefig(rad_outfile + '.pdf')
+            ax.clabel(scalar_contour, colors='darkblue', fmt='%1.0f')
+
+            ax.annotate('Radial Wind (m s-1)', xy=(14, 350), color='darkgreen')
+            ax.annotate('Temperature (K)', xy=(14, 370), color='darkblue')
+
+            ax.set_xlabel(
+                'Range (RMW = %4.1f km)' % track_data['RMW'][track_index])
+            ax.set_xticks(np.arange(1, 20))
+
+            ax.set_yscale('symlog')
+
+            if by_pressure_lvl:
+                ax.set_ylabel('Pressure (mb)')
+                ax.set_ylim(1000, 250)
+                ax.set_yticks(np.arange(1000, 250, -100))
+                ax.set_yticklabels(np.arange(1000, 250, -100))
+            else:
+                ax.set_ylabel('Height (m)')
+                ax.set_ylim(110, 10359)
+                ax.set_yticks(np.arange(110, 10359, 1000))
+                ax.set_yticklabels(np.arange(110, 10359, 1000))
+
+            rad_outfile = os.path.join(plotdir,
+                                       'radial_cross_section_' + str(valid_time[track_index]))
+            # plt.savefig(os.path.join(plotdir, 'tc_cross_section.png'), dpi=300)
+            # plt.savefig(os.path.join(plotdir, 'tc_cross_section.pdf'))
+
+            fig.savefig(rad_outfile + '.png', dpi=300)
+            fig.savefig(rad_outfile + '.pdf')
 
 
 if __name__ == '__main__':

--- a/metplotpy/contributed/tc_rmw/plot_cross_section.py
+++ b/metplotpy/contributed/tc_rmw/plot_cross_section.py
@@ -18,6 +18,14 @@ def plot_cross_section(plotdir,
        Generate the cross-section plot of the tangential and radial wind
     """
 
+    # azimuthal mean
+    wind_radial = np.mean(wind_data['radial'], axis=1)
+    wind_tangential = np.mean(wind_data['tangential'], axis=1)
+    scalar_field = np.mean(scalar_data[field], axis=1)
+    logging.debug(wind_radial.shape)
+    logging.debug(wind_tangential.shape)
+    logging.debug(scalar_field.shape)
+
     wind_types = ['tangential', 'radial']
     for wt in wind_types:
         fig, ax = plt.subplots(figsize=(8., 4.5))
@@ -25,14 +33,6 @@ def plot_cross_section(plotdir,
 
         plt.title(
             format_valid_time(int(valid_time[track_index])))
-
-        # azimuthal mean
-        wind_radial = np.mean(wind_data['radial'], axis=1)
-        wind_tangential = np.mean(wind_data['tangential'], axis=1)
-        scalar_field = np.mean(scalar_data[field], axis=1)
-        logging.debug(wind_radial.shape)
-        logging.debug(wind_tangential.shape)
-        logging.debug(scalar_field.shape)
 
         if wt == 'tangential':
             wind_contour = ax.contour(range_grid, pressure_grid,
@@ -56,6 +56,7 @@ def plot_cross_section(plotdir,
 
             ax.set_yscale('symlog')
 
+            # provide support for wind data in pressure or height
             if by_pressure_lvl:
                 ax.set_ylabel('Pressure (mb)')
                 ax.set_ylim(1000, 250)
@@ -69,9 +70,7 @@ def plot_cross_section(plotdir,
 
             tang_outfile = os.path.join(plotdir,
                                         'tangential_cross_section_' + str(valid_time[track_index]))
-            # plt.savefig(os.path.join(plotdir, 'tc_cross_section.png'), dpi=300)
-            # plt.savefig(os.path.join(plotdir, 'tc_cross_section.pdf'))
-
+            
             fig.savefig(tang_outfile + '.png', dpi=300)
             fig.savefig(tang_outfile + '.pdf')
         else:
@@ -96,6 +95,7 @@ def plot_cross_section(plotdir,
 
             ax.set_yscale('symlog')
 
+            # provide support for wind data in pressure or height
             if by_pressure_lvl:
                 ax.set_ylabel('Pressure (mb)')
                 ax.set_ylim(1000, 250)
@@ -109,8 +109,6 @@ def plot_cross_section(plotdir,
 
             rad_outfile = os.path.join(plotdir,
                                        'radial_cross_section_' + str(valid_time[track_index]))
-            # plt.savefig(os.path.join(plotdir, 'tc_cross_section.png'), dpi=300)
-            # plt.savefig(os.path.join(plotdir, 'tc_cross_section.pdf'))
 
             fig.savefig(rad_outfile + '.png', dpi=300)
             fig.savefig(rad_outfile + '.pdf')

--- a/metplotpy/contributed/tc_rmw/plot_cross_section.yaml
+++ b/metplotpy/contributed/tc_rmw/plot_cross_section.yaml
@@ -1,0 +1,44 @@
+# Sample YAML configuration file for generating a wind cross-section plot
+# based on pressure or height (from vertical interpolation via METcalcpy module
+# vertical_interpolation).
+
+
+#
+# Vertical coordinate information:
+#
+
+vertical_coord_type_in:
+# The input type of the vertical coordinate;
+# accepted values are 'pressure' or 'height'.
+# The 'height' type is obtained by applying the METcalcpy
+# vertical_interpolation module on 'pressure' input.
+  'pressure'
+#  'height'
+
+
+vertical_dim_name:
+  'pressure'
+#  'height'
+
+
+# vertical levels based on height
+#vertical_levels:
+#  - 100
+#  - 200
+#  - 500
+#  - 1000
+#  - 2000
+#  - 3000
+#  - 4000
+
+# for vertical levels based on pressure
+vertical_levels:
+  - 1000
+  - 250
+
+
+vertical_level_stepsize:
+  # the step size between levels (e.g. -100 mb when vertical level is by pressure
+  # or 200 meters when vertical level is by height)
+  - -100
+#  - 500

--- a/metplotpy/contributed/tc_rmw/tc_utils.py
+++ b/metplotpy/contributed/tc_rmw/tc_utils.py
@@ -123,7 +123,14 @@ def radial_tangential_winds(
     valid_time, range_grid, azimuth_grid, pressure_grid, wind_data):
     """
     Compute radial and tangential components from zonal and meridional components.
+
+    Args:
+
+    Returns:
+        radial_tangential_wind_data:  a dictionary containing the radial and tangential
+                                      wind data
     """
+    radial_tangential_wind_data = {}
     n_t = len(valid_time)
     n_r = len(range_grid)
     n_a = len(azimuth_grid)
@@ -144,8 +151,10 @@ def radial_tangential_winds(
 
     wind_radial = np.cos(theta) * wind_data['U'] + np.sin(theta) * wind_data['V']
     wind_tangential = - np.sin(theta) * wind_data['U'] + np.cos(theta) * wind_data['V']
-    wind_data['radial'] = wind_radial
-    wind_data['tangential'] = wind_tangential
+    radial_tangential_wind_data['radial'] = wind_radial
+    radial_tangential_wind_data['tangential'] = wind_tangential
+
+    return radial_tangential_wind_data
 
 def height_from_pressure(surface_pressure, virtual_temperature, pressure):
     """

--- a/metplotpy/contributed/tc_rmw/test_plot_cross_section.sh
+++ b/metplotpy/contributed/tc_rmw/test_plot_cross_section.sh
@@ -1,20 +1,17 @@
-#export datadir=$HOME/Data/TCRMW
+
 export datadir=/Volumes/d1/minnawin/METcalcpy_Data/Vert_Interp
-#export plotdir=$HOME/Plots
+
 export plotdir=/Volumes/d1/minnawin/METplotpy_37_vert_interp/Plots
-# export datadir=$DATA_DIR/TCRMW
-# export plotdir=$PLOT_DIR
+
 export filename=tc_rmw_dev_test_out.nc
-# leave empty if plotting by height in meters (i.e vertical interpolation used)
-# or set to something (like 'yes' or 'True', etc) if pressure input data
-# is in pressure (mb)
-export by_pressure_lvl=yes
+
+export configfile=/Volumes/d1/minnawin/METplotpy_37_vert_interp/METplotpy/metplotpy/contributed/tc_rmw/plot_cross_section.yaml
 
 python plot_cross_section.py \
     --datadir=$datadir \
     --plotdir=$plotdir \
     --filename=$filename \
-    --by_pressure_lvl=$by_pressure_lvl
+    --config=$configfile
 
 #python plot_cross_section.py \
 #    --datadir=$datadir \

--- a/metplotpy/contributed/tc_rmw/test_plot_cross_section.sh
+++ b/metplotpy/contributed/tc_rmw/test_plot_cross_section.sh
@@ -5,8 +5,9 @@ export plotdir=/Volumes/d1/minnawin/METplotpy_37_vert_interp/Plots
 # export datadir=$DATA_DIR/TCRMW
 # export plotdir=$PLOT_DIR
 export filename=tc_rmw_dev_test_out.nc
-# leave empty if plotting by height (vertical interpolation used)
-# or set to True if plotting by pressure level
+# leave empty if plotting by height in meters (i.e vertical interpolation used)
+# or set to something (like 'yes' or 'True', etc) if pressure input data
+# is in pressure (mb)
 export by_pressure_lvl=yes
 
 python plot_cross_section.py \

--- a/metplotpy/contributed/tc_rmw/test_plot_cross_section.sh
+++ b/metplotpy/contributed/tc_rmw/test_plot_cross_section.sh
@@ -1,10 +1,21 @@
-export datadir=$HOME/Data/TCRMW
-export plotdir=$HOME/Plots
+#export datadir=$HOME/Data/TCRMW
+export datadir=/Volumes/d1/minnawin/METcalcpy_Data/Vert_Interp
+#export plotdir=$HOME/Plots
+export plotdir=/Volumes/d1/minnawin/METplotpy_37_vert_interp/Plots
 # export datadir=$DATA_DIR/TCRMW
 # export plotdir=$PLOT_DIR
 export filename=tc_rmw_dev_test_out.nc
+# leave empty if plotting by height (vertical interpolation used)
+# or set to True if plotting by pressure level
+export by_pressure_lvl=yes
 
 python plot_cross_section.py \
     --datadir=$datadir \
     --plotdir=$plotdir \
-    --filename=$filename
+    --filename=$filename \
+    --by_pressure_lvl=$by_pressure_lvl
+
+#python plot_cross_section.py \
+#    --datadir=$datadir \
+#    --plotdir=$plotdir \
+#    --filename=$filename \


### PR DESCRIPTION
## Pull Request Testing ##

Just need a code review/sanity check.  Code is not ready for merging with the develop branch, it is still a "work in progress".  Requires incorporating the use of vertically interpolated input that is created from the METcalcpy vertical_interpolation module.  I am still using the input data that is in pressure levels that was originally used to generate the pressure level plots. 


**Changes made:**

1) I added a config file to handle either pressure or heights: METplotpy/metplotpy/contributed/tc_rmw/plot_cross_section.yaml


2) I am returning a dictionary of the tangential and radial wind information from the METplotpy/metplotpy/contributed/tc_rmw/tc_utils.py function, radial_tangential_winds()

3) I added support for generating both the radial and tangential wind plots and made the plots configurable, based on the settings in the plot_cross_section.yaml config file in the METplotpy/metplotpy/contributed/tc_rmw/plot_cross_section.py module

4) I updated the METplotpy/metplotpy/contributed/tc_rmw/test_plot_cross_section.sh run script to run on my Mac laptop using the netCDF data as input (datadir).

    on 'kiowa', I have the tc_rmw_dev_test_out.nc on:
_/d1/personal/minnawin/VertInterp_Data_

