### PR TITLE
Bugfix #482  support any variation of 1, true in show_legend settings…

### DIFF
--- a/metplotpy/plots/config.py
+++ b/metplotpy/plots/config.py
@@ -355,10 +355,21 @@ class Config:
                be used for the traces
         """
         show_legend_settings = self.get_config_value('show_legend')
+
+        # Support all variations of setting the show_legend: '1', 1, "true" (any combination of cases), True (boolean)
+        updated_show_legend_settings = []
+        for legend_setting in show_legend_settings:
+            legend_setting = str(legend_setting).lower()
+            if legend_setting == '1' or legend_setting == 'true' or legend_setting == 1 or legend_setting is True:
+                updated_show_legend_settings.append(int(1))
+            else:
+                updated_show_legend_settings.append(int(0))
+
+
         if show_legend_settings is None:
             raise ValueError("ERROR: show_legend parameter is not provided.")
 
-        return self.create_list_by_series_ordering(list(show_legend_settings))
+        return self.create_list_by_series_ordering(list(updated_show_legend_settings))
 
     def _get_markers(self):
         """


### PR DESCRIPTION
… (in the YAML config file)

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>

    generated line plots using the following YAML config file and sample data:


   modified the show_legend setting to:
     - 1
     - '1'
     - 'true'
     - 'TRue'
     - truE 

 and verified the generated plots have the legend label
     - values other than 1, '1', true (any case combination):
        - false
        - False
        - 0
        
and verified the generated plots do NOT have the legend labels displayed, as requested.

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>

on 'seneca':

- METcalcpy (develop) and METplotpy (feature_482_legend_labels) are located at:
       /d1/projects/PR_METplotpy_482

- run in bash shell

- activate this conda environment:

    /d1/personal/mwin/miniconda3/envs/mp_analysis_env

- Test using the debug.yaml and debug.data file located in the /d1/projects/PR_METplotpy_482/METplotpy/metplotpy/plots/line directory
        - **modify the following setting ** to verify that the legend labels show or are hidden, based on setting 'True' (any variation of capitalization/lower case), 1, '1' to show and anything else.  
    
    **!!! line 171 !!!**


      show_legend:
           - 'FALSE'

- Generate the plot by running:

      python line.py debug.yaml

- A plot named plot_legends.png will be generated:

  
SHOW LEGEND TURNED OFF:
<img width="747" alt="no_legend_example" src="https://github.com/user-attachments/assets/f07830eb-85f5-4c89-88e9-5d213cbc0ff5" />


SHOW LEGEND TURNED ON:


<img width="749" alt="show_legend_example" src="https://github.com/user-attachments/assets/fbeab29d-94c1-4b4a-b84d-60e95786076e" />




- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[NA]**

- [x] Do these changes include sufficient testing updates? **[NA]**

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Do these changes introduce new SonarQube findings? **[No]**</br>
If **yes**, please describe: **possible** QualityGate findings since this code may be considered "new"

- [x] Please complete this pull request review by before Beta2 release.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [ ] Add any new Python packages to the [METplus Components Python Requirements](https://metplus.readthedocs.io/en/develop/Users_Guide/appendixA.html#metplus-components-python-packages) table.
- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR definition above.
- [ ] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **METplotpy-X.Y.Z Development** project for official releases
- [ ] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
