### PR TITLE
Ignore any NA/None values when checking for min and max values for co…

### DIFF
--- a/metplotpy/plots/line/line.py
+++ b/metplotpy/plots/line/line.py
@@ -787,12 +787,21 @@ class Line(BasePlot):
         """
         # calculate series upper and lower limits of CIs
         indexes = range(len(series.series_points['dbl_med']))
-        upper_range = [
-            series.series_points['dbl_med'][i] + series.series_points['dbl_up_ci'][i]
-            for i in indexes]
-        low_range = [
-            series.series_points['dbl_med'][i] - series.series_points['dbl_lo_ci'][i]
-            for i in indexes]
+
+        # Check for NA/None values when searching for upper range values and
+        # ignore them.
+        upper_range = []
+        for i in indexes:
+            if series.series_points['dbl_med'][i] is not None and series.series_points['dbl_up_ci'][i] is not None:
+                upper_range.append(series.series_points['dbl_med'][i] + series.series_points['dbl_up_ci'][i])
+
+        # Check for NA/None values when searching for lower range values and
+        # ignore them.
+        low_range = []
+        for i in indexes:
+            if series.series_points['dbl_med'][i] is not None and series.series_points['dbl_lo_ci'][i] is not None:
+                low_range.append(series.series_points['dbl_med'][i] - series.series_points['dbl_lo_ci'][i])
+
         # find min max
         if yaxis_min is None or yaxis_max is None:
             return min(low_range), max(upper_range)


### PR DESCRIPTION


This will prevent any errors due to performing arithmetic on None/NA values that were encountered using the data provided by the user (from the METplus Discussions while attempting to generate a plot with two y-axis using the same scale).

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
- ran tests to verify that the "correct" plot is being produced
- testing with Python 3.12

Original issue was with attempting to sync the y-axis when errors were encountered using this data:
[reformat.data.txt](https://github.com/user-attachments/files/19435893/reformat.data.txt)

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
- verify that tests pass
- if account key permits/time permits:
- on 'seneca' /d1/projects/bugfix_494_METplotpy directory, generate plots
   - run in bash shell
   - cd to /d1/projects/bugfix_494_METplotpy/METplotpy/metplotpy/plots/line
   - use Python 312 conda environment py_312 from this path:  /d1/personal/mwin/miniconda3/envs/mp_py312
        -   `conda activate /d1/personal/mwin/miniconda3/envs/mp_py312`
   - set the path using this script: /d1/projects/bugfix_494_METplotpy/setup_env.bash
   - to generate a plot with sync'd y-axes (so the scales are the same):
      - in the plot.yaml config file, set the sync_axes: 'True'
      - `python /d1/projects/bugfix_494_METplotpy/METplotpy/metplotpy/plots/line/line.py /d1/projects/bugfix_494_METplotpy/METplotpy/metplotpy/plots/line/plot.yaml`
    
      - plot should look like this:
      ![plot](https://github.com/user-attachments/assets/631236c9-ffa0-4c17-9d0b-9e2d0f243aa9)

      - change the sync_yaxes: 'False'
          plot should look like this:
![plot_no_sync](https://github.com/user-attachments/assets/0e997e2f-8fcc-4181-b961-56c53fdc2849)


- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[NA]**

- [x] Do these changes include sufficient testing updates? **[NA]**

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>

- [x] Do these changes introduce new SonarQube findings? **[unknown]**</br>
If **yes**, please describe: may have error due to test coverage below 80%

- [x] Please complete this pull request review by **ASAP for Wednesday Beta2 release**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [ ] Add any new Python packages to the [METplus Components Python Requirements](https://metplus.readthedocs.io/en/develop/Users_Guide/appendixA.html#metplus-components-python-packages) table.
- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR definition above.
- [ ] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **METplotpy-X.Y.Z Development** project for official releases
- [ ] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
