### PR TITLE
bugfix 495, when bootstrapped CI's are requested, perform an addition…

### DIFF
--- a/metplotpy/plots/line/line_series.py
+++ b/metplotpy/plots/line/line_series.py
@@ -326,6 +326,7 @@ class LineSeries(Series):
             if len(point_data) > 0:
                 # calculate point stat
                 point_stat = self._calc_point_stat(point_data['stat_value'].tolist())
+                logger.info(f"Calculated point statistic: {point_stat}")
 
                 # calculate CI
                 dbl_lo_ci = 0
@@ -366,8 +367,30 @@ class LineSeries(Series):
                         if stat_btcl == -9999:
                             stat_btcl = 0
 
-                    dbl_lo_ci = point_stat - stat_btcl
-                    dbl_up_ci = stat_btcu - point_stat
+                        dbl_lo_ci = point_stat - stat_btcl
+                        dbl_up_ci = stat_btcu - point_stat
+
+                        if dbl_lo_ci is None or np.isnan(dbl_lo_ci):
+                          logger.info(f"for {self.config.list_stat_1}= {point_stat} Low value CI is None/NaN, no error bar will be plotted ")
+                        if dbl_up_ci is None or  np.isnan(dbl_up_ci):
+                          logger.info(f"for {self.config.list_stat_1}= {point_stat} Upper value CI is None/NaN, no error bar will be plotted")
+
+                    elif 'stat_bcu' in point_data.head() and 'stat_bcl' in point_data.head():
+                        stat_bcu = self._calc_point_stat(point_data['stat_bcu'].tolist())
+                        stat_bcl = self._calc_point_stat(point_data['stat_bcl'].tolist())
+
+                        if stat_bcu == -9999:
+                            stat_bcu = 0
+                        if stat_bcl == -9999:
+                            stat_bcl = 0
+
+                        dbl_lo_ci = point_stat - stat_bcl
+                        dbl_up_ci = stat_bcu - point_stat
+
+                        if dbl_lo_ci is None or np.isnan(dbl_lo_ci):
+                          logger.info(f"for {self.config.list_stat_1}= {point_stat} Low value CI is None/NaN, no error bar will be plotted ")
+                        if dbl_up_ci is None or  np.isnan(dbl_up_ci):
+                          logger.info(f"for {self.config.list_stat_1}= {point_stat} Upper value CI is None/NaN, no error bar will be plotted")
 
                 elif series_ci == 'MET_BOOT':
                     stat_bcu = 0


### PR DESCRIPTION
Errors with input data and requested bootstrap CI calculations- the plot looks like this, with incorrect error bars:
![ci_bars_incorrect](https://github.com/user-attachments/assets/3d929c00-43fe-40cd-b83f-bcfe230aede6)


Fix: check for the presence of bcl/bcu columns in addition to btcl/btcu columns.

## Pull Request Testing ##

- [x] Describe testing already performed for these changes:</br>
- re-ran all METplotpy tests
- on 'seneca', generated the correct plot
- verified that the log file indicates which points have btcu/btcl values that are NaN/None

- [x] Recommend testing for the reviewer(s) to perform, including the location of input datasets, and any additional instructions:</br>
- verify that all necessary Github tests pass
- **TIME PERMITTING (based on account key balances):**
    
   -  on 'seneca' /d1/projects/bugfix_495_confidence_limits directory, generate plots
   - run in bash shell
   - cd to /d1/projects/bugfix_495_confidence_limits/METplotpy/metplotpy/plots/line
   - use Python 312 conda environment py_312 from this path:  /d1/personal/mwin/miniconda3/envs/mp_py312
        -   `conda activate /d1/personal/mwin/miniconda3/envs/mp_py312`
   - set the path using this script: /d1/projects/bugfix_495_confidence_limits/setup_env.bash
       - `cd /d1/projects/bugfix_495_confidence_limits`
       - `source setup_env.bash`
   - to generate a plot with no error bars (because values are NaN/NA), the log file will indicate that no error bars will be plotted to provide users with helpful information:
      
      - `python /d1/projects/bugfix_495_confidence_limits/METplotpy/metplotpy/plots/line/line.py /d1/projects/bugfix_495_confidence_limits/METplotpy/metplotpy/plots/line/plot_20250311_012114.yaml`
    
      - plot should look like this:
  
![zero_ci_bars](https://github.com/user-attachments/assets/5c38c4aa-7c68-4703-89ae-5d6f8309257e)



- [x] Do these changes include sufficient documentation updates, ensuring that no errors or warnings exist in the build of the documentation? **[NA]**

- [x] Do these changes include sufficient testing updates? **[NA]**

- [x] Will this PR result in changes to the test suite? **[No]**</br>
If **yes**, describe the new output and/or changes to the existing output:</br>


- [x] Do these changes introduce new SonarQube findings? **[probably]**</br>
If **yes**, please describe: due to code coverage values below 80%

- [x] Please complete this pull request review by **ASAP for beta2 release on Wed March 26**.</br>

## Pull Request Checklist ##
See the [METplus Workflow](https://metplus.readthedocs.io/en/latest/Contributors_Guide/github_workflow.html) for details.
- [ ] Add any new Python packages to the [METplus Components Python Requirements](https://metplus.readthedocs.io/en/develop/Users_Guide/appendixA.html#metplus-components-python-packages) table.
- [ ] Review the source issue metadata (required labels, projects, and milestone).
- [ ] Complete the PR definition above.
- [ ] Ensure the PR title matches the feature or bugfix branch name.
- [ ] Define the PR metadata, as permissions allow.
Select: **Reviewer(s)** and **Development** issue
Select: **Milestone** as the version that will include these changes
Select: **Coordinated METplus-X.Y Support** project for bugfix releases or **METplotpy-X.Y.Z Development** project for official releases
- [ ] After submitting the PR, select the :gear: icon in the **Development** section of the right hand sidebar. Search for the issue that this PR will close and select it, if it is not already selected.
- [ ] After the PR is approved, merge your changes. If permissions do not allow this, request that the reviewer do the merge.
- [ ] Close the linked issue and delete your feature or bugfix branch from GitHub.
